### PR TITLE
Add AddOptionsProviderBuilder + AddOptionsProvider with no path

### DIFF
--- a/src/OptionsProvider/OptionsProvider/OptionsProvider.csproj
+++ b/src/OptionsProvider/OptionsProvider/OptionsProvider.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
 		<PackageId>OptionsProvider</PackageId>
-		<Version>1.0.1</Version>
+		<Version>1.1.0</Version>
 		<Authors>Justin D. Harris</Authors>
 		<Nullable>enable</Nullable>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/OptionsProvider/OptionsProvider/ServiceCollectionExtensions.cs
+++ b/src/OptionsProvider/OptionsProvider/ServiceCollectionExtensions.cs
@@ -30,19 +30,23 @@ public static class ServiceCollectionExtensions
 	/// Uses <see cref="AddOptionsProviderBuilder(IServiceCollection)"/>.
 	/// </remarks>
 	/// <param name="services">The current service collection for dependency injection.</param>
-	/// <param name="path">The base directory to start searching for files that represent features.</param>
+	/// <param name="path">(optional) The base directory to start searching for files that represent features.</param>
 	/// <param name="featureConfigurations">(optional) Additional custom configurations for features.</param>
 	/// <returns>The <see cref="IServiceCollection"/> for chaining calls.</returns>
 	public static IServiceCollection AddOptionsProvider(
 		this IServiceCollection services,
-		string path,
+		string? path = null,
 		IEnumerable<FeatureConfiguration>? featureConfigurations = null)
 	{
 		services.AddOptionsProviderBuilder();
 		services.TryAddSingleton<IOptionsProvider>(serviceProvider =>
 		{
 			var builder = serviceProvider.GetRequiredService<IOptionsProviderBuilder>();
-			builder.AddDirectoryAsync(path).Wait();
+			if (path is not null)
+			{
+				builder.AddDirectoryAsync(path).Wait();
+			}
+
 			if (featureConfigurations is not null)
 			{
 				foreach (var featureConfiguration in featureConfigurations)

--- a/src/OptionsProvider/OptionsProvider/ServiceCollectionExtensions.cs
+++ b/src/OptionsProvider/OptionsProvider/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
 namespace OptionsProvider;
@@ -10,8 +11,24 @@ namespace OptionsProvider;
 public static class ServiceCollectionExtensions
 {
 	/// <summary>
+	/// Sets up <see cref="IOptionsProviderBuilder"/> to be ready for injecting as a dependency.
+	/// </summary>
+	/// <param name="services">The current service collection for dependency injection.</param>
+	/// <returns>The <see cref="IServiceCollection"/> for chaining calls.</returns>
+	public static IServiceCollection AddOptionsProviderBuilder(
+		this IServiceCollection services)
+	{
+		services.AddMemoryCache();
+		services.TryAddTransient<IOptionsProviderBuilder, OptionsProviderBuilder>();
+		return services;
+	}
+
+	/// <summary>
 	/// Sets up <see cref="IOptionsProvider"/> to be ready for injecting as a dependency.
 	/// </summary>
+	/// <remarks>
+	/// Uses <see cref="AddOptionsProviderBuilder(IServiceCollection)"/>.
+	/// </remarks>
 	/// <param name="services">The current service collection for dependency injection.</param>
 	/// <param name="path">The base directory to start searching for files that represent features.</param>
 	/// <param name="featureConfigurations">(optional) Additional custom configurations for features.</param>
@@ -21,9 +38,8 @@ public static class ServiceCollectionExtensions
 		string path,
 		IEnumerable<FeatureConfiguration>? featureConfigurations = null)
 	{
-		services.AddMemoryCache();
-		services.AddTransient<IOptionsProviderBuilder, OptionsProviderBuilder>();
-		services.AddSingleton<IOptionsProvider>(serviceProvider =>
+		services.AddOptionsProviderBuilder();
+		services.TryAddSingleton<IOptionsProvider>(serviceProvider =>
 		{
 			var builder = serviceProvider.GetRequiredService<IOptionsProviderBuilder>();
 			builder.AddDirectoryAsync(path).Wait();
@@ -37,7 +53,7 @@ public static class ServiceCollectionExtensions
 			return builder.Build();
 		});
 
-		services.AddScoped<IFeaturesContext, FeaturesContext>();
+		services.TryAddScoped<IFeaturesContext, FeaturesContext>();
 
 		return services;
 	}

--- a/src/OptionsProvider/Tests/OptionsProviderBuilderTests.cs
+++ b/src/OptionsProvider/Tests/OptionsProviderBuilderTests.cs
@@ -50,6 +50,13 @@ public sealed class OptionsProviderBuilderTests
 	}
 
 	[TestMethod]
+	public async Task Test_AddDirectoryAsync_with_Existing_Name()
+	{
+		var builder = ServiceProvider.GetRequiredService<IOptionsProviderBuilder>();
+		await Test_InvalidConfigurations(builder);
+	}
+
+	[TestMethod]
 	public async Task Test_Builder_Only()
 	{
 		// Ensure that we can get only a builder.
@@ -64,13 +71,6 @@ public sealed class OptionsProviderBuilderTests
 
 		await Test_InvalidConfigurations(optionsProviderBuilder);
 		Test_SetConfigurationSource_with_Existing_Name(optionsProviderBuilder);
-	}
-
-	[TestMethod]
-	public async Task Test_AddDirectoryAsync_with_Existing_Name()
-	{
-		var builder = ServiceProvider.GetRequiredService<IOptionsProviderBuilder>();
-		await Test_InvalidConfigurations(builder);
 	}
 
 	[TestMethod]

--- a/src/OptionsProvider/Tests/OptionsProviderBuilderTests.cs
+++ b/src/OptionsProvider/Tests/OptionsProviderBuilderTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Memory;
 using Microsoft.Extensions.DependencyInjection;
+using OptionsProvider.Tests.TestConfigs;
 
 namespace OptionsProvider.Tests;
 
@@ -10,10 +11,8 @@ public sealed class OptionsProviderBuilderTests
 {
 	// Won't be `null` when running tests.
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-#pragma warning disable CA2211 // Non-constant fields should not be visible
-	public static IServiceProvider ServiceProvider;
-	public static IOptionsProvider OptionsProvider;
-#pragma warning restore CA2211 // Non-constant fields should not be visible
+	internal static IServiceProvider ServiceProvider;
+	internal static IOptionsProvider OptionsProvider;
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
 	[AssemblyInitialize]
@@ -51,9 +50,38 @@ public sealed class OptionsProviderBuilderTests
 	}
 
 	[TestMethod]
+	public async Task Test_Builder_Only()
+	{
+		// Ensure that we can get only a builder.
+		var configuration = new ConfigurationBuilder()
+			.AddJsonFile("appsettings.json")
+			.Build();
+		using var serviceProvider = new ServiceCollection()
+			.AddSingleton<IConfiguration>(configuration)
+			.AddOptionsProviderBuilder()
+			.BuildServiceProvider();
+		var optionsProviderBuilder = serviceProvider.GetRequiredService<IOptionsProviderBuilder>();
+
+		await Test_InvalidConfigurations(optionsProviderBuilder);
+		Test_SetConfigurationSource_with_Existing_Name(optionsProviderBuilder);
+	}
+
+	[TestMethod]
 	public async Task Test_AddDirectoryAsync_with_Existing_Name()
 	{
 		var builder = ServiceProvider.GetRequiredService<IOptionsProviderBuilder>();
+		await Test_InvalidConfigurations(builder);
+	}
+
+	[TestMethod]
+	public void Test_SetConfigurationSource_with_Existing_Name()
+	{
+		var builder = ServiceProvider.GetRequiredService<IOptionsProviderBuilder>();
+		Test_SetConfigurationSource_with_Existing_Name(builder);
+	}
+
+	private static async Task Test_InvalidConfigurations(IOptionsProviderBuilder builder)
+	{
 		var action = () => builder.AddDirectoryAsync("InvalidConfigurations");
 		await action.Should().ThrowAsync<InvalidOperationException>()
 			.WithMessage($"Error loading the configuration file at \"{Path.Combine("InvalidConfigurations", "other example.json")}\".")
@@ -61,8 +89,7 @@ public sealed class OptionsProviderBuilderTests
 			.WithMessage($"The alias \"other example\" for \"other example\" is already used as an alias or feature name.");
 	}
 
-	[TestMethod]
-	public void Test_SetConfigurationSource_with_Existing_Name()
+	private static void Test_SetConfigurationSource_with_Existing_Name(IOptionsProviderBuilder builder)
 	{
 		var metadata = new OptionsMetadata
 		{
@@ -70,7 +97,6 @@ public sealed class OptionsProviderBuilderTests
 			Aliases = ["alias"],
 			Owners = "owner",
 		};
-		var builder = ServiceProvider.GetRequiredService<IOptionsProviderBuilder>();
 		var configSource = new MemoryConfigurationSource
 		{
 			InitialData = new Dictionary<string, string?>

--- a/src/OptionsProvider/Tests/OptionsProviderTests.cs
+++ b/src/OptionsProvider/Tests/OptionsProviderTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using OptionsProvider.Tests.TestConfigs;
 
 namespace OptionsProvider.Tests;
 

--- a/src/OptionsProvider/Tests/TestConfigs/EntireConfig.cs
+++ b/src/OptionsProvider/Tests/TestConfigs/EntireConfig.cs
@@ -1,4 +1,4 @@
-﻿namespace OptionsProvider.Tests;
+﻿namespace OptionsProvider.Tests.TestConfigs;
 
 internal sealed class EntireConfig
 {

--- a/src/OptionsProvider/Tests/TestConfigs/MyConfiguration.cs
+++ b/src/OptionsProvider/Tests/TestConfigs/MyConfiguration.cs
@@ -1,4 +1,4 @@
-﻿namespace OptionsProvider.Tests;
+﻿namespace OptionsProvider.Tests.TestConfigs;
 
 /// <summary>
 /// An example configuration for tests.

--- a/src/OptionsProvider/Tests/TestConfigs/NonCachedConfiguration.cs
+++ b/src/OptionsProvider/Tests/TestConfigs/NonCachedConfiguration.cs
@@ -1,4 +1,4 @@
-﻿namespace OptionsProvider.Tests;
+﻿namespace OptionsProvider.Tests.TestConfigs;
 
 /// <summary>
 /// An example configuration for tests that looks the same as <see cref="MyConfiguration"/> but is not cached.


### PR DESCRIPTION
Helps if only a builder is needed.
`AddOptionsProvider`: support null path for no configuration files.